### PR TITLE
A more precise targetting of elements.

### DIFF
--- a/jquery.tabslet.js
+++ b/jquery.tabslet.js
@@ -70,7 +70,7 @@
       _tabs.each(function() { _cache_div.push($(this).css('display')); });
 
       // Autorotate
-      var elements = $this.find('> ul li'), i = options.active - 1; // ungly
+      var elements = $this.find('> ul > li'), i = options.active - 1; // ungly
 
       if ( !$this.data( 'tabslet-init' ) ) {
 


### PR DESCRIPTION
Problem:
If you have "li" in an elements, when you click on it, you'll have an error (no tabs will be displayed).

Solution:
Targetting the "li" with the child selectors (">").