### PR TITLE
Prevent the default action on controls

### DIFF
--- a/jquery.tabslet.js
+++ b/jquery.tabslet.js
@@ -203,12 +203,14 @@
 
         }
 
-        $this.find(options.controls.next).click(function() {
+        $this.find(options.controls.next).click(function(e) {
           move('forward');
+          e.preventDefault();
         });
 
-        $this.find(options.controls.prev).click(function() {
+        $this.find(options.controls.prev).click(function(e) {
           move('backward');
+          e.preventDefault();
         });
 
         $this.on ('show', function(e, tab) {


### PR DESCRIPTION
If you have a <a> as controls (<a href="#tab_ID">), it will jump to the anchor on click. To avoid that, the solution is to add a preventDefault to the event on the controls click.